### PR TITLE
fix: Prevent git clone from hanging on auth prompts

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -167,6 +167,7 @@ func (s *svc) reset(ctx context.Context) error {
 
 func (s *svc) exec(ctx context.Context, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
When cloning sources via HTTPS that require authentication, and credentials are not available (e.g., no credential helper or cached credentials), git commands would previously hang waiting for terminal input (username/password). This caused `devbox up` or `devbox update` to appear stuck in the "syncing" phase indefinitely.

This change modifies the git command execution to set the `GIT_TERMINAL_PROMPT=0` environment variable. This instructs Git to fail immediately if it requires interactive terminal input, rather than prompting.

The existing error handling in devbox should then capture and display the error message from Git (e.g., "fatal: could not read Username for 'https://example.com': terminal prompts disabled"), providing clear feedback to you about the cause of the sync failure.