### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Enable version updates for Go
+  - package-ecosystem: "gomod"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Configure Dependabot for Go with weekly updates

This commit updates the Dependabot configuration to check for Go dependency updates weekly instead of daily. Output:
Configure Dependabot for Go with weekly updates

This commit updates the Dependabot configuration to check for Go dependency updates weekly instead of daily.