### PR TITLE
fix: use git clean -fdx to remove gitignored files from sources

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -76,7 +76,7 @@ func (s *svc) Sync(ctx context.Context, url, branch string, sparseCheckout []str
 	}
 
 	if isExist {
-		if err := s.reset(ctx); err != nil {
+		if err := s.reset(ctx, true); err != nil {
 			return fmt.Errorf("failed to reset repo %s: %w", s.targetPath, err)
 		}
 	} else {
@@ -113,7 +113,7 @@ func (s *svc) Sync(ctx context.Context, url, branch string, sparseCheckout []str
 }
 
 func (s *svc) Pull(ctx context.Context) error {
-	if err := s.reset(ctx); err != nil {
+	if err := s.reset(ctx, false); err != nil {
 		return fmt.Errorf("failed to reset repo: %w", err)
 	}
 
@@ -162,7 +162,7 @@ func (s *svc) GetTopLevel(ctx context.Context) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
-func (s *svc) reset(ctx context.Context) error {
+func (s *svc) reset(ctx context.Context, removeIgnored bool) error {
 	_ = os.Remove(filepath.Join(s.targetPath, ".git/index.lock"))
 
 	out, err := s.runner.Run(ctx, "git", "-C", s.targetPath, "reset", "--hard")
@@ -170,7 +170,12 @@ func (s *svc) reset(ctx context.Context) error {
 		return fmt.Errorf("failed to reset: %s %w", out, err)
 	}
 
-	out, err = s.runner.Run(ctx, "git", "-C", s.targetPath, "clean", "-fd")
+	cleanFlags := "-fd"
+	if removeIgnored {
+		cleanFlags = "-fdx"
+	}
+
+	out, err = s.runner.Run(ctx, "git", "-C", s.targetPath, "clean", cleanFlags)
 	if err != nil {
 		return fmt.Errorf("failed to clean: %s %w", out, err)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -441,6 +441,7 @@ func TestSync(t *testing.T) {
 				m.EXPECT().RunWithTTY(mock.Anything, "git", "clone", "--no-checkout", "--depth", "1", "https://github.com/org/repo.git", targetPath).Return("", nil)
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "sparse-checkout", "disable").Return("", nil)
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "checkout", "main").Return("", nil)
+				// Pull's reset (removeIgnored=false)
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "reset", "--hard").Return("", nil)
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "clean", "-fd").Return("", nil)
 				m.EXPECT().RunWithTTY(mock.Anything, "git", "-C", targetPath, "pull", "--rebase").Return("", nil)
@@ -457,6 +458,7 @@ func TestSync(t *testing.T) {
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "sparse-checkout", "init", "--cone").Return("", nil)
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "sparse-checkout", "set", "src", "docs").Return("", nil)
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "checkout", "main").Return("", nil)
+				// Pull's reset (removeIgnored=false)
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "reset", "--hard").Return("", nil)
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "clean", "-fd").Return("", nil)
 				m.EXPECT().RunWithTTY(mock.Anything, "git", "-C", targetPath, "pull", "--rebase").Return("", nil)
@@ -469,14 +471,14 @@ func TestSync(t *testing.T) {
 			setupGit:       true,
 			sparseCheckout: nil,
 			setupMock: func(m *MockCommandRunner, targetPath string) {
-				// reset() called first
+				// Sync's reset (removeIgnored=true)
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "reset", "--hard").Return("", nil).Once()
-				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "clean", "-fd").Return("", nil).Once()
+				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "clean", "-fdx").Return("", nil).Once()
 				// sparse-checkout disable
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "sparse-checkout", "disable").Return("", nil)
 				// checkout
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "checkout", "main").Return("", nil)
-				// Pull calls reset() again
+				// Pull's reset (removeIgnored=false)
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "reset", "--hard").Return("", nil).Once()
 				m.EXPECT().Run(mock.Anything, "git", "-C", targetPath, "clean", "-fd").Return("", nil).Once()
 				m.EXPECT().RunWithTTY(mock.Anything, "git", "-C", targetPath, "pull", "--rebase").Return("", nil)


### PR DESCRIPTION
## Problem

Empty `.env` files accumulate in source checkout dirs because they're gitignored and `git clean -fd` skips them. This causes issues with Docker bind mounts — VirtioFS sees the empty file instead of the actual `.env` mounted from `envs/`, so containers start with zero-byte config.

## Fix

Use `git clean -fdx` in `Sync()` to also remove gitignored files from source checkouts. Keep `-fd` in `Pull()` since it runs on the project directory where `.env` is intentionally excluded via `.git/info/exclude` and must be preserved.