### PR TITLE
fix: detect TTY with real isatty check instead of char-device test

### DIFF
--- a/cmd/devbox/run.go
+++ b/cmd/devbox/run.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/spf13/cobra"
@@ -91,7 +92,7 @@ func runRun(ctx context.Context, p *project.Project, command string, args []stri
 	case scenario.Tty != nil:
 		tty = *scenario.Tty
 	default:
-		tty = isTTYAvailable()
+		tty = isTTYAvailable(os.Stdin)
 	}
 
 	opts := project.RunOptions{

--- a/cmd/devbox/shell.go
+++ b/cmd/devbox/shell.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/pilat/devbox/internal/project"
 )
@@ -84,7 +85,7 @@ func runShell(ctx context.Context, p *project.Project, serviceName string, noTty
 	if noTtyFlag {
 		tty = false
 	} else {
-		tty = isTTYAvailable()
+		tty = isTTYAvailable(os.Stdin)
 	}
 
 	opts := project.RunOptions{
@@ -160,11 +161,6 @@ func filterLabels(projectName, serviceName string) client.Filters {
 		Add("label", "com.docker.compose.container-number=1")
 }
 
-func isTTYAvailable() bool {
-	stat, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
-
-	return (stat.Mode() & os.ModeCharDevice) != 0
+func isTTYAvailable(f *os.File) bool {
+	return term.IsTerminal(int(f.Fd()))
 }

--- a/cmd/devbox/tty_test.go
+++ b/cmd/devbox/tty_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsTTYAvailable(t *testing.T) {
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("failed to open %s: %v", os.DevNull, err)
+	}
+	t.Cleanup(func() { devNull.Close() })
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "tty")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	t.Cleanup(func() { tmpFile.Close() })
+
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		pipeR.Close()
+		pipeW.Close()
+	})
+
+	tests := []struct {
+		name string
+		file *os.File
+		want bool
+	}{
+		{name: "dev null is not a terminal", file: devNull, want: false},
+		{name: "regular file is not a terminal", file: tmpFile, want: false},
+		{name: "pipe is not a terminal", file: pipeR, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTTYAvailable(tt.file); got != tt.want {
+				t.Errorf("isTTYAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

`devbox run <scenario>` and `devbox shell` fail in any non-interactive environment — CI,
background jobs, `nohup`, or stdin redirected from `/dev/null` — with:

> cannot attach stdin to a TTY-enabled container because stdin is not a terminal

This happens even for scenarios that rely on TTY **auto-detection** (no explicit `tty:` set).

The root cause is a too-loose terminal check. `isTTYAvailable` treated any character device
as a terminal:

```go
return (stat.Mode() & os.ModeCharDevice) != 0
```

But `/dev/null` — what a detached/headless process gets on stdin — is a character device
that is **not** a terminal. devbox then forced `tty=true` on the compose `exec`, and the
docker/cli layer below correctly refused it. devbox's own detection and docker/cli's
enforcement disagreed exactly on `/dev/null`.

## What

- **Use a real isatty check.** Replace the `ModeCharDevice` test with `golang.org/x/term`'s
  `term.IsTerminal(int(f.Fd()))`. It performs the same `tcget` ioctl docker/cli uses
  downstream, so devbox's detection and the compose layer's enforcement now agree.
- **Inject stdin as a parameter** — `isTTYAvailable(f *os.File)` — so the detection is unit
  testable instead of reaching for the global `os.Stdin`.
- **Add a regression test** covering the non-terminal cases: `/dev/null`, a regular file,
  and a pipe. The `/dev/null` case is the one that failed under the old logic.

## Notes

- Only the auto-detect path changes. An explicit `tty:` in a scenario config still takes
  precedence and is untouched.
- `golang.org/x/term` was already a direct dependency (used by `internal/table`), so no new
  modules — `go.mod`/`go.sum` are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the app detects whether an interactive terminal is available.
  * Interactive commands now make better decisions about when to enable terminal-based behavior, especially when input is piped or redirected.
  * This should make shell and scenario execution more reliable across different terminal environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->