### PR TITLE
fix: forward extra arguments to devbox run scenarios

### DIFF
--- a/cmd/devbox/run.go
+++ b/cmd/devbox/run.go
@@ -12,13 +12,17 @@ import (
 )
 
 func init() {
+	root.AddCommand(newRunCmd())
+}
+
+func newRunCmd() *cobra.Command {
 	var noTty bool
 
 	cmd := &cobra.Command{
 		Use:   "run <scenario>",
 		Short: "Run scenario defined in devbox project",
 		Long:  "You can pass additional arguments to the scenario",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MinimumNArgs(1),
 		ValidArgsFunction: validArgsWrapper(
 			func(ctx context.Context, cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 				p, err := mgr.AutodetectProject(ctx, projectName)
@@ -40,14 +44,9 @@ func init() {
 				return fmt.Errorf("failed to detect project: %w", err)
 			}
 
-			command := args[0]
-			if len(args) > 1 {
-				args = args[1:]
-			} else {
-				args = []string{}
-			}
+			scenario, passthrough := splitScenarioArgs(args)
 
-			if err := runRun(ctx, p, command, args, noTty); err != nil {
+			if err := runRun(ctx, p, scenario, passthrough, noTty); err != nil {
 				return fmt.Errorf("failed to run scenario: %w", err)
 			}
 
@@ -58,7 +57,21 @@ func init() {
 	cmd.Flags().BoolVarP(&noTty, "no-tty", "t", false, "Do not allocate a pseudo-TTY")
 	cmd.Flags().SetInterspersed(false)
 
-	root.AddCommand(cmd)
+	return cmd
+}
+
+// splitScenarioArgs returns the scenario name and its forwarded args, consuming one leading "--".
+func splitScenarioArgs(args []string) (scenario string, passthrough []string) {
+	scenario = args[0]
+	passthrough = args[1:]
+
+	// Interspersing is off, so pflag never consumes the "--"; drop one leading
+	// separator so `run e2e -- --tag` and `run e2e --tag` forward the same args.
+	if len(passthrough) > 0 && passthrough[0] == "--" {
+		passthrough = passthrough[1:]
+	}
+
+	return scenario, passthrough
 }
 
 func runRun(ctx context.Context, p *project.Project, command string, args []string, noTtyFlag bool) error {

--- a/cmd/devbox/run_test.go
+++ b/cmd/devbox/run_test.go
@@ -12,12 +12,32 @@ func TestSplitScenarioArgs(t *testing.T) {
 		wantScenario    string
 		wantPassthrough []string
 	}{
-		{name: "flag only", args: []string{"e2e", "--tag", "foo"}, wantScenario: "e2e", wantPassthrough: []string{"--tag", "foo"}},
-		{name: "separator stripped", args: []string{"e2e", "--", "--tag", "foo"}, wantScenario: "e2e", wantPassthrough: []string{"--tag", "foo"}},
+		{
+			name:            "flag only",
+			args:            []string{"e2e", "--tag", "foo"},
+			wantScenario:    "e2e",
+			wantPassthrough: []string{"--tag", "foo"},
+		},
+		{
+			name:            "separator stripped",
+			args:            []string{"e2e", "--", "--tag", "foo"},
+			wantScenario:    "e2e",
+			wantPassthrough: []string{"--tag", "foo"},
+		},
 		{name: "no args", args: []string{"e2e"}, wantScenario: "e2e", wantPassthrough: nil},
 		{name: "bare separator", args: []string{"e2e", "--"}, wantScenario: "e2e", wantPassthrough: nil},
-		{name: "double separator keeps second", args: []string{"e2e", "--", "--"}, wantScenario: "e2e", wantPassthrough: []string{"--"}},
-		{name: "later separator untouched", args: []string{"e2e", "--tag", "--", "foo"}, wantScenario: "e2e", wantPassthrough: []string{"--tag", "--", "foo"}},
+		{
+			name:            "double separator keeps second",
+			args:            []string{"e2e", "--", "--"},
+			wantScenario:    "e2e",
+			wantPassthrough: []string{"--"},
+		},
+		{
+			name:            "later separator untouched",
+			args:            []string{"e2e", "--tag", "--", "foo"},
+			wantScenario:    "e2e",
+			wantPassthrough: []string{"--tag", "--", "foo"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -43,7 +63,11 @@ func TestRunCmdArgsContract(t *testing.T) {
 		wantErr  bool
 	}{
 		{name: "flag only", argv: []string{"e2e", "--tag", "foo"}, wantArgs: []string{"e2e", "--tag", "foo"}},
-		{name: "explicit separator", argv: []string{"e2e", "--", "--tag", "foo"}, wantArgs: []string{"e2e", "--", "--tag", "foo"}},
+		{
+			name:     "explicit separator",
+			argv:     []string{"e2e", "--", "--tag", "foo"},
+			wantArgs: []string{"e2e", "--", "--tag", "foo"},
+		},
 		{name: "scenario only", argv: []string{"e2e"}, wantArgs: []string{"e2e"}},
 		{name: "no scenario", argv: []string{}, wantErr: true},
 	}

--- a/cmd/devbox/run_test.go
+++ b/cmd/devbox/run_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSplitScenarioArgs(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		wantScenario    string
+		wantPassthrough []string
+	}{
+		{name: "flag only", args: []string{"e2e", "--tag", "foo"}, wantScenario: "e2e", wantPassthrough: []string{"--tag", "foo"}},
+		{name: "separator stripped", args: []string{"e2e", "--", "--tag", "foo"}, wantScenario: "e2e", wantPassthrough: []string{"--tag", "foo"}},
+		{name: "no args", args: []string{"e2e"}, wantScenario: "e2e", wantPassthrough: nil},
+		{name: "bare separator", args: []string{"e2e", "--"}, wantScenario: "e2e", wantPassthrough: nil},
+		{name: "double separator keeps second", args: []string{"e2e", "--", "--"}, wantScenario: "e2e", wantPassthrough: []string{"--"}},
+		{name: "later separator untouched", args: []string{"e2e", "--tag", "--", "foo"}, wantScenario: "e2e", wantPassthrough: []string{"--tag", "--", "foo"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scenario, passthrough := splitScenarioArgs(tt.args)
+			if scenario != tt.wantScenario {
+				t.Errorf("scenario = %q, want %q", scenario, tt.wantScenario)
+			}
+			if !slices.Equal(passthrough, tt.wantPassthrough) {
+				t.Errorf("passthrough = %v, want %v", passthrough, tt.wantPassthrough)
+			}
+		})
+	}
+}
+
+// TestRunCmdArgsContract guards the real command's validator + SetInterspersed(false)
+// against a revert to ExactArgs, which would break scenario argument pass-through.
+func TestRunCmdArgsContract(t *testing.T) {
+	tests := []struct {
+		name     string
+		argv     []string
+		wantArgs []string
+		wantErr  bool
+	}{
+		{name: "flag only", argv: []string{"e2e", "--tag", "foo"}, wantArgs: []string{"e2e", "--tag", "foo"}},
+		{name: "explicit separator", argv: []string{"e2e", "--", "--tag", "foo"}, wantArgs: []string{"e2e", "--", "--tag", "foo"}},
+		{name: "scenario only", argv: []string{"e2e"}, wantArgs: []string{"e2e"}},
+		{name: "no scenario", argv: []string{}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRunCmd()
+			if err := cmd.ParseFlags(tt.argv); err != nil {
+				t.Fatalf("ParseFlags(%v) failed: %v", tt.argv, err)
+			}
+
+			got := cmd.Flags().Args()
+			err := cmd.ValidateArgs(got)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateArgs(%v) = nil, want error", got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ValidateArgs(%v) failed: %v", got, err)
+			}
+			if !slices.Equal(got, tt.wantArgs) {
+				t.Errorf("Flags().Args() = %v, want %v", got, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/docs/run.md
+++ b/docs/run.md
@@ -26,6 +26,9 @@ devbox run test
 # Run a test scenario with arguments
 devbox run test --verbose --suite=api
 
+# The same, using -- as an explicit separator (optional; it is consumed, not forwarded)
+devbox run test -- --verbose --suite=api
+
 # Run a scenario in a specific project
 devbox --name project-name run test
 ```


### PR DESCRIPTION
## Why

`devbox run <scenario> [args...]` is documented to forward extra arguments to the scenario's command (`docs/run.md` shows `devbox run test --verbose --suite=api`), but today **any** extra argument makes the command fail before the scenario ever runs. Both `devbox run e2e --tag foo` and `devbox run e2e -- --tag foo` error out with `accepts 1 arg(s), received N`.

The cause is two lines that contradict each other: `Args: cobra.ExactArgs(1)` rejects any argv beyond the scenario name, which silently defeats the `SetInterspersed(false)` that exists specifically to enable pass-through.

## What

- Relax the validator: `cobra.ExactArgs(1)` → `cobra.MinimumNArgs(1)`. A scenario name is still required; extra args are now accepted.
- Keep `SetInterspersed(false)` so the flag-only form (`run e2e --tag foo`, no `--`) works and tokens after the scenario name are forwarded rather than swallowed by devbox's own flags.
- Strip exactly one **leading** `--` from the forwarded args so both `run e2e --tag foo` and `run e2e -- --tag foo` forward a clean `[--tag foo]` — matching the docker/cargo/npm separator convention. A `--` appearing later is passed through untouched.
- Document the explicit-separator form in `docs/run.md`.

## Notes

- **Only the `run` command changes.** `shell.go` also uses `ExactArgs(1)`, but that is correct — `shell` takes exactly one service name with no pass-through — so it is left alone.
- The command construction is extracted into `newRunCmd()` so the regression tests bind to the **real** command object (real validator + `SetInterspersed(false)`) rather than a hand-rebuilt copy that could drift. The contract test is what guards against a future revert to `ExactArgs`.
- Tests are Docker-free: a table-driven unit test over the arg-splitting helper, plus a cobra contract test asserting the parse/validate behavior for the flag-only, `--`-separated, single-arg, and no-scenario cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `devbox run` now accepts flexible argument passing, making it easier to forward flags to scenarios.
  * A leading `--` is now treated as an explicit separator and won’t be passed through unexpectedly.
* **Documentation**
  * Added an example showing the updated `devbox run` argument format and forwarding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->