### PR TITLE
chore: bump copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Vladimir Urushev
+Copyright (c) 2026 Vladimir Urushev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 DevBox is licensed under the MIT License.  
-© 2025 Vladimir Urushev
+© 2026 Vladimir Urushev


### PR DESCRIPTION
The copyright year in LICENSE and README has been stuck at 2025. Updating to 2026 to keep things current — a small bit of housekeeping that is easy to forget otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated copyright notices in the license and README to reflect 2026.
  * All other license terms remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->